### PR TITLE
fix: @nestjs/common type import is duplicated

### DIFF
--- a/lib/interfaces/http-module.interface.ts
+++ b/lib/interfaces/http-module.interface.ts
@@ -1,6 +1,4 @@
-import type { Provider } from '@nestjs/common';
-import type { ModuleMetadata } from '@nestjs/common';
-import type { Type } from '@nestjs/common';
+import type { Provider, ModuleMetadata, Type } from '@nestjs/common';
 import type { HttpModuleOptions } from '../types/http-module.type';
 
 export interface HttpModuleOptionsFactory {


### PR DESCRIPTION
In `lib/interfaces/http-module.interface.ts` @nestjs/common type import is duplicated

```mts
import type { Provider } from '@nestjs/common';
import type { ModuleMetadata } from '@nestjs/common';
...
```