### PR TITLE
Update tests to support v7 and fix peers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "rimraf": "5.0.10",
         "rxjs": "7.8.1",
         "ts-jest": "29.2.5",
-        "typescript": "5.7.3"
+        "typescript": "5.7.3",
+        "undici": "^7.8.0"
       },
       "engines": {
         "node": ">=18",
@@ -44,7 +45,7 @@
         "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^6.0.0 || ^7.0.0",
-        "undici": "^5.28.5"
+        "undici": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1044,15 +1045,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -13296,16 +13288,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -14602,12 +14591,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true
-    },
-    "@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-      "peer": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -23021,13 +23004,10 @@
       }
     },
     "undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
-      "peer": true,
-      "requires": {
-        "@fastify/busboy": "^2.0.0"
-      }
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
+      "dev": true
     },
     "undici-types": {
       "version": "6.20.0",

--- a/package.json
+++ b/package.json
@@ -57,13 +57,14 @@
     "rimraf": "5.0.10",
     "rxjs": "7.8.1",
     "ts-jest": "29.2.5",
-    "typescript": "5.7.3"
+    "typescript": "5.7.3",
+    "undici": "^7.8.0"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^6.0.0 || ^7.0.0",
-    "undici": "^5.28.5"
+    "undici": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "contributors": [
     {

--- a/src/shared/mocks/body.mock.ts
+++ b/src/shared/mocks/body.mock.ts
@@ -10,5 +10,12 @@ export const bodyMock = {
       test: 'test',
     }),
   text: () => Promise.resolve('test'),
-  body: new BodyReadable(),
+  body: new BodyReadable({
+    resume() {
+      return;
+    },
+    abort() {
+      return;
+    },
+  }),
 } as any;

--- a/src/shared/mocks/dispatcher.mock.ts
+++ b/src/shared/mocks/dispatcher.mock.ts
@@ -4,6 +4,7 @@ import type { Dispatcher } from 'undici';
 const duplex = new stream.Duplex();
 
 export const dispatcherMock: Dispatcher = {
+  compose: () => dispatcherMock,
   dispatch: () => true,
   pipeline: () => duplex,
   connect: (


### PR DESCRIPTION
I confirmed v5, v6, and v7 function by running them against Node 20 and Node 22 to verify all the tests passed and that they worked locally. Then I updated the peer dependencies to reflect the correct compatibility.

I also added undici as a dev dependency and fixed the mock data to support the latest version.

Fixes #274 